### PR TITLE
[WIP] Handle 302 status for upload-ipa and for upload-apk

### DIFF
--- a/upload-apk.js
+++ b/upload-apk.js
@@ -43,6 +43,9 @@ var result = fetch('https://testbuild.rocks/api/builds/upload/' + program.projec
         if (res.status == 200) {
             return res;
         }
+        if (res.status == 302) {
+            throw new Error('Failed to upload build to testbuild.rocks: variable TEST_BUILD_ROCKS_KEY is not specified');
+        }
         return res.text().then(function (body) {
             throw new Error('Failed to upload build to testbuild.rocks [' + body + ']');
         });

--- a/upload-ipa.js
+++ b/upload-ipa.js
@@ -45,6 +45,9 @@ var result = fetch(program.server + '/api/builds/upload/' + program.projectId + 
         if (res.status == 200) {
             return res;
         }
+        if (res.status == 302) {
+            throw new Error('Failed to upload build to testbuild.rocks: variable TEST_BUILD_ROCKS_KEY is not specified');
+        }
         return res.text().then(function (body) {
             throw new Error('Failed to upload build to testbuild.rocks [' + body + ']');
         });


### PR DESCRIPTION
I have faced with the issue when we don't have TEST_BUILD_ROCKS_KEY in the project, in this way we see only success messages on both: success on pipeline and 302 on the testbuild.rocks